### PR TITLE
Added Clone to Evaluator trait

### DIFF
--- a/src/evaluators.rs
+++ b/src/evaluators.rs
@@ -5,7 +5,7 @@ Utilities for turning values within a certain range into different curves.
 /**
 Trait that any evaluators must implement. Must return an `f32` value between `0.0..=100.0`.
  */
-pub trait Evaluator: std::fmt::Debug + Sync + Send {
+pub trait Evaluator: std::fmt::Debug + Sync + Send + Clone {
     fn evaluate(&self, value: f32) -> f32;
 }
 


### PR DESCRIPTION
Hey! Not sure if this is correct, but if I am operating arbitrarily over some `Evaluator`, I'd like to be able to copy it, especially when passing that trait from a builder. 