### PR TITLE
Make choices mod public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ pub mod evaluators;
 pub mod pickers;
 
 pub mod actions;
-mod choices;
+pub mod choices;
 pub mod scorers;
 pub mod thinker;
 


### PR DESCRIPTION
Makes the choices mod public so that alternate pickers can be created.