### PR TITLE
Added EvaluatingScorer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,5 +201,6 @@ impl Plugin for BigBrainPlugin {
         app.add_system(scorers::all_or_nothing_system.system());
         app.add_system(scorers::sum_of_scorers_system.system());
         app.add_system(scorers::winning_scorer_system.system());
+        app.add_system(scorers::evaluating_scorer_system.system());
     }
 }

--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -370,7 +370,7 @@ unlike other composite scorers, `EvaluatingScorer` only takes one scorer upon bu
 ```ignore
 Thinker::build()
     .when(
-        WinningScorer::build(MyScorer, MyEvaluator),
+        EvaluatingScorer::build(MyScorer, MyEvaluator),
         MyAction::build());
 ```
  */


### PR DESCRIPTION
This adds a way to more easily use an `Evaluator` while building a thinker.  For instance, we can build something like -

```rs
...
.when(
    EvaluatingScorer::build(scorers::MyScorer::build(), LinearEvaluator::new_inversed()),
    actions::MyAction::build(),
)
...
```

\- to inverse a scorer, without needing to modify it. 