### PR TITLE
Don't include Bevy default features when used as a dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,7 @@ repository = "https://github.com/zkat/big-brain"
 homepage = "https://github.com/zkat/big-brain"
 
 [dependencies]
-bevy = "0.5.0"
+bevy = { version = "0.5.0", default-features = false }
 
+[dev-dependencies]
+bevy = { version = "0.5.0", default-features = true }


### PR DESCRIPTION
Without this change, this plugin pulls in dependencies for Bevy features I don't need when used as a plugin (E.g. the audio feature is enabled even though neither I nor this plugin require it.) All features are re-enabled in `[dev-dependencies]` so examples are unconstrained.