### PR TITLE
Bevy main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/zkat/big-brain"
 homepage = "https://github.com/zkat/big-brain"
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git", branch = "main" }
+bevy = { version = "0.6.0", defaut-features = false }
 
 [dev-dependencies]
-bevy = {  git = "https://github.com/bevyengine/bevy.git", branch = "main" }
+bevy = { version = "0.6.0", default-features = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "big-brain"
 version = "0.8.1-alpha.0"
 authors = ["Kat Marchán <kzm@zkat.tech>"]
-edition = "2018"
+edition = "2021"
 description = "Rusty Utility AI library"
 license = "Apache-2.0"
 readme = "README.md"
@@ -12,7 +12,7 @@ repository = "https://github.com/zkat/big-brain"
 homepage = "https://github.com/zkat/big-brain"
 
 [dependencies]
-bevy = { version = "0.5.0", default-features = false }
+bevy = { git = "https://github.com/bevyengine/bevy.git", branch = "main" }
 
 [dev-dependencies]
-bevy = { version = "0.5.0", default-features = true }
+bevy = {  git = "https://github.com/bevyengine/bevy.git", branch = "main" }

--- a/examples/thirst.rs
+++ b/examples/thirst.rs
@@ -125,7 +125,7 @@ impl ScorerBuilder for ThirstyBuilder {
     }
 }
 
-// Looks familiar? It's a lot likee Actions!
+// Looks familiar? It's a lot like Actions!
 pub fn thirsty_scorer_system(
     thirsts: Query<&Thirst>,
     // Same dance with the Parent here, but now Big Brain has added a Score component!

--- a/examples/thirst.rs
+++ b/examples/thirst.rs
@@ -165,9 +165,9 @@ fn main() {
     App::build()
         .add_plugins(DefaultPlugins)
         .add_plugin(BigBrainPlugin)
-        .add_startup_system(init_entities.system())
-        .add_system(thirst_system.system())
-        .add_system(drink_action_system.system())
-        .add_system(thirsty_scorer_system.system())
+        .add_startup_system(init_entities)
+        .add_system(thirst_system)
+        .add_system(drink_action_system)
+        .add_system(thirsty_scorer_system)
         .run();
 }

--- a/examples/thirst.rs
+++ b/examples/thirst.rs
@@ -6,7 +6,7 @@ use big_brain::prelude::*;
 // time. This is what the AI will later interact with.
 //
 // There's nothing special here. It's a plain old Bevy component.
-#[derive(Debug)]
+#[derive(Component, Debug)]
 pub struct Thirst {
     pub per_second: f32,
     pub thirst: f32,
@@ -36,7 +36,7 @@ pub fn thirst_system(time: Res<Time>, mut thirsts: Query<&mut Thirst>) {
 //
 // These actions will be spawned and queued by the game engine when their
 // conditions trigger (we'll configure what these are later).
-#[derive(Debug, Clone)]
+#[derive(Clone, Component, Debug)]
 pub struct Drink;
 
 // The convention is to attach a `::build()` function to the Action type.
@@ -48,7 +48,7 @@ impl Drink {
 
 // Then we define an ActionBuilder, which is responsible for making new
 // Action components for us.
-#[derive(Debug, Clone)]
+#[derive(Clone, Component, Debug)]
 pub struct DrinkBuilder;
 
 // All you need to implement heree is the `build()` method, which requires
@@ -107,7 +107,7 @@ fn drink_action_system(
 // ScorerBuilder and Scorer components. While it might seem like a lot of
 // boilerplate, in a "real" application, you will almost certainly have data
 // and configuration concerns. This pattern separates those nicely.
-#[derive(Debug, Clone)]
+#[derive(Clone, Component, Debug)]
 pub struct Thirsty;
 
 impl Thirsty {
@@ -162,7 +162,7 @@ pub fn init_entities(mut cmd: Commands) {
 
 fn main() {
     // Once all that's done, we just add our systems and off we go!
-    App::build()
+    App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(BigBrainPlugin)
         .add_startup_system(init_entities)

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -10,7 +10,7 @@ use crate::thinker::{ActionEnt, Actor};
 /**
 The current state for an Action.
 */
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Component, Eq, PartialEq)]
 pub enum ActionState {
     /**
     Initial state. No action should be performed.
@@ -149,7 +149,7 @@ Thinker::build()
         )
 ```
 */
-#[derive(Debug)]
+#[derive(Component, Debug)]
 pub struct Steps {
     steps: Vec<Arc<dyn ActionBuilder>>,
     active_step: usize,
@@ -284,7 +284,7 @@ Thinker::build()
         )
 ```
 */
-#[derive(Debug)]
+#[derive(Component, Debug)]
 pub struct Concurrently {
     actions: Vec<ActionEnt>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,32 +192,32 @@ App::build()
 pub struct BigBrainPlugin;
 
 impl Plugin for BigBrainPlugin {
-    fn build(&self, app: &mut AppBuilder) {
+    fn build(&self, app: &mut App) {
         use CoreStage::*;
         app.add_system_set_to_stage(
             First,
             SystemSet::new()
-                .with_system(scorers::fixed_score_system.system())
-                .with_system(scorers::all_or_nothing_system.system())
-                .with_system(scorers::sum_of_scorers_system.system())
-                .with_system(scorers::winning_scorer_system.system())
-                .with_system(scorers::evaluating_scorer_system.system())
+                .with_system(scorers::fixed_score_system)
+                .with_system(scorers::all_or_nothing_system)
+                .with_system(scorers::sum_of_scorers_system)
+                .with_system(scorers::winning_scorer_system)
+                .with_system(scorers::evaluating_scorer_system)
                 .label("scorers"),
         );
-        app.add_system_to_stage(First, thinker::thinker_system.system().after("scorers"));
+        app.add_system_to_stage(First, thinker::thinker_system.after("scorers"));
 
         app.add_system_set_to_stage(
             PreUpdate,
             SystemSet::new()
-                .with_system(actions::steps_system.system())
-                .with_system(actions::concurrent_system.system())
+                .with_system(actions::steps_system)
+                .with_system(actions::concurrent_system)
                 .label("aggregate-actions"),
         );
 
         // run your actions in PreUpdate after aggregate-actions or in a later stage
 
-        app.add_system_to_stage(Last, thinker::thinker_component_attach_system.system());
-        app.add_system_to_stage(Last, thinker::thinker_component_detach_system.system());
-        app.add_system_to_stage(Last, thinker::actor_gone_cleanup.system());
+        app.add_system_to_stage(Last, thinker::thinker_component_attach_system);
+        app.add_system_to_stage(Last, thinker::thinker_component_detach_system);
+        app.add_system_to_stage(Last, thinker::actor_gone_cleanup);
     }
 }

--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -14,7 +14,7 @@ use crate::{
 /**
 Score value between `0.0..=1.0` associated with a Scorer.
  */
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Component, Debug, Default)]
 pub struct Score(pub(crate) f32);
 
 impl Score {
@@ -80,7 +80,7 @@ pub trait ScorerBuilder: std::fmt::Debug + Sync + Send {
 /**
 Scorer that always returns the same, fixed score. Good for combining with things creatively!
  */
-#[derive(Debug, Clone)]
+#[derive(Clone, Component, Debug)]
 pub struct FixedScore(f32);
 
 impl FixedScore {
@@ -95,7 +95,7 @@ pub fn fixed_score_system(mut query: Query<(&FixedScore, &mut Score)>) {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Component, Debug)]
 pub struct FixedScoreBuilder(f32);
 
 impl ScorerBuilder for FixedScoreBuilder {
@@ -118,7 +118,7 @@ Thinker::build()
         MyAction::build());
 ```
  */
-#[derive(Debug)]
+#[derive(Component, Debug)]
 pub struct AllOrNothing {
     threshold: f32,
     scorers: Vec<ScorerEnt>,
@@ -204,7 +204,7 @@ Thinker::build()
         MyAction::build());
 ```
  */
-#[derive(Debug)]
+#[derive(Component, Debug)]
 pub struct SumOfScorers {
     threshold: f32,
     scorers: Vec<ScorerEnt>,
@@ -287,7 +287,7 @@ Thinker::build()
 ```
  */
 
-#[derive(Debug)]
+#[derive(Component, Debug)]
 pub struct WinningScorer {
     threshold: f32,
     scorers: Vec<ScorerEnt>,
@@ -376,7 +376,7 @@ Thinker::build()
         MyAction::build());
 ```
  */
-#[derive(Debug, Clone)]
+#[derive(Clone, Component, Debug)]
 pub struct EvaluatingScorer {
     scorer: ScorerEnt,
     evaluator: Arc<dyn Evaluator>,

--- a/src/thinker.rs
+++ b/src/thinker.rs
@@ -19,13 +19,13 @@ use crate::{
 /**
 Wrapper for Actor entities. In terms of Scorers, Thinkers, and Actions, this is the [`Entity`] actually _performing_ the action, rather than the entity a Scorer/Thinker/Action is attached to. Generally, you will use this entity when writing Queries for Action and Scorer systems.
  */
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Component, Copy)]
 pub struct Actor(pub Entity);
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Component, Copy)]
 pub(crate) struct ActionEnt(pub Entity);
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Component, Copy)]
 pub(crate) struct ScorerEnt(pub Entity);
 
 /**
@@ -50,7 +50,7 @@ pub fn init_entities(mut cmd: Commands) {
 }
 ```
  */
-#[derive(Debug)]
+#[derive(Component, Debug)]
 pub struct Thinker {
     picker: Arc<dyn Picker>,
     otherwise: Option<ActionBuilderWrapper>,
@@ -70,7 +70,7 @@ impl Thinker {
 /**
 This is what you actually use to configure Thinker behavior. It's a plain old [`ActionBuilder`], as well.
  */
-#[derive(Debug, Default)]
+#[derive(Component, Debug, Default)]
 pub struct ThinkerBuilder {
     picker: Option<Arc<dyn Picker>>,
     otherwise: Option<ActionBuilderWrapper>,
@@ -172,7 +172,7 @@ pub fn actor_gone_cleanup(
     }
 }
 
-#[derive(Debug)]
+#[derive(Component, Debug)]
 pub struct HasThinker(Entity);
 
 pub struct ThinkerIterations {

--- a/src/thinker.rs
+++ b/src/thinker.rs
@@ -2,12 +2,12 @@
 Thinkers are the "brain" of an entity. You attach Scorers to it, and the Thinker picks the right Action to run based on the resulting Scores.
 */
 
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::sync::Arc;
 
-use bevy::prelude::*;
+use bevy::{
+    prelude::*,
+    utils::{Duration, Instant},
+};
 
 use crate::{
     actions::{self, ActionBuilder, ActionBuilderWrapper, ActionState},

--- a/tests/steps.rs
+++ b/tests/steps.rs
@@ -8,13 +8,13 @@ fn steps() {
         .add_plugins(MinimalPlugins)
         .add_plugin(BigBrainPlugin)
         .init_resource::<GlobalState>()
-        .add_startup_system(setup.system())
-        .add_system_to_stage(CoreStage::First, no_failure_score.system())
-        .add_system(action1.system())
-        .add_system(action2.system())
-        .add_system(exit_action.system())
-        .add_system(failure_action.system())
-        .add_system_to_stage(CoreStage::Last, last.system())
+        .add_startup_system(setup)
+        .add_system_to_stage(CoreStage::First, no_failure_score)
+        .add_system(action1)
+        .add_system(action2)
+        .add_system(exit_action)
+        .add_system(failure_action)
+        .add_system_to_stage(CoreStage::Last, last)
         .run();
     println!("end");
 }

--- a/tests/steps.rs
+++ b/tests/steps.rs
@@ -4,7 +4,7 @@ use big_brain::{pickers, prelude::*};
 #[test]
 fn steps() {
     println!("steps test");
-    App::build()
+    App::new()
         .add_plugins(MinimalPlugins)
         .add_plugin(BigBrainPlugin)
         .init_resource::<GlobalState>()
@@ -28,7 +28,7 @@ fn setup(mut cmds: Commands) {
     );
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Clone, Component, Debug, Default)]
 struct Action1;
 impl ActionBuilder for Action1 {
     fn build(&self, cmd: &mut Commands, action: Entity, _actor: Entity) {
@@ -50,7 +50,7 @@ fn action1(mut query: Query<(&Actor, &mut ActionState), With<Action1>>) {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Clone, Component, Debug, Default)]
 struct Action2;
 impl ActionBuilder for Action2 {
     fn build(&self, cmd: &mut Commands, action: Entity, _actor: Entity) {
@@ -72,7 +72,7 @@ fn action2(mut query: Query<(&Actor, &mut ActionState), With<Action2>>) {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Clone, Component, Debug, Default)]
 struct ExitAction;
 impl ActionBuilder for ExitAction {
     fn build(&self, cmd: &mut Commands, action: Entity, _actor: Entity) {
@@ -101,7 +101,7 @@ fn last() {
     println!();
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Clone, Component, Debug, Default)]
 struct FailureAction;
 impl ActionBuilder for FailureAction {
     fn build(&self, cmd: &mut Commands, action: Entity, _actor: Entity) {
@@ -132,7 +132,7 @@ struct GlobalState {
     failure: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Component, Debug)]
 struct NoFailureScore;
 impl ScorerBuilder for NoFailureScore {
     fn build(&self, cmd: &mut Commands, action: Entity, _actor: Entity) {


### PR DESCRIPTION
Bevy 0.6 is coming Soon™ now that the new renderer has been merged into main. I've only tested this with the example and the steps test, but it seems to work. (cargo test fails as I haven't updated the docs).

Changes:

- #[derive(Component)] is now required for Components (although cart was talking about potentially reverting that change)
- Rust 2021 for the new feature resolver
- AppBuilder was folded into App, and you now use App::new() instead of AppBuilder::build()
- QuerySets now use QueryState instead of Query (and was causing problems, until I realized you could probably just replace where you used them a single Query now)
- .system() is no longer required when registering systems, so I just removed them
- and most importantly, reordering the #[derive(...)] so that they're in alphabetical order
- edit: Now uses bevy::utils::Instant and Duration over std::time for WASM support