### PR TITLE
Allow custom scorers to be created

### DIFF
--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -15,7 +15,7 @@ use crate::{
 Score value between `0.0..=1.0` associated with a Scorer.
  */
 #[derive(Clone, Component, Debug, Default)]
-pub struct Score(pub f32);
+pub struct Score(pub(crate) f32);
 
 impl Score {
     /**

--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -15,7 +15,7 @@ use crate::{
 Score value between `0.0..=1.0` associated with a Scorer.
  */
 #[derive(Clone, Component, Debug, Default)]
-pub struct Score(pub(crate) f32);
+pub struct Score(pub f32);
 
 impl Score {
     /**

--- a/src/thinker.rs
+++ b/src/thinker.rs
@@ -26,7 +26,7 @@ pub struct Actor(pub Entity);
 pub(crate) struct ActionEnt(pub Entity);
 
 #[derive(Debug, Clone, Component, Copy)]
-pub(crate) struct ScorerEnt(pub Entity);
+pub struct ScorerEnt(pub Entity);
 
 /**
 The "brains" behind this whole operation. A `Thinker` is what glues together `Actions` and `Scorers` and shapes larger, intelligent-seeming systems.


### PR DESCRIPTION
Currently it isn't possible to create custom scorers as `Score` and `ScoreEnt` are `pub(crate)`. This PR makes these `pub` so that custom scorers can be built.