### PR TITLE
Add ProductOfScorers composite scorer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,7 @@ impl Plugin for BigBrainPlugin {
                 .with_system(scorers::fixed_score_system)
                 .with_system(scorers::all_or_nothing_system)
                 .with_system(scorers::sum_of_scorers_system)
+                .with_system(scorers::product_of_scorers_system)
                 .with_system(scorers::winning_scorer_system)
                 .with_system(scorers::evaluating_scorer_system),
         );

--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -368,7 +368,7 @@ pub struct ProductOfScorersBuilder {
 impl ProductOfScorersBuilder {
     /// To account for the fact that the total score will be reduced for scores with more inputs,
     /// we can optionally apply a compensation factor by calling this and passing `true`
-    pub fn apply_compensation(mut self, use_compensation: bool) -> Self {
+    pub fn use_compensation(mut self, use_compensation: bool) -> Self {
         self.use_compensation = use_compensation;
         self
     }

--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -337,12 +337,12 @@ pub fn product_of_scorers_system(
 
         for ScorerEnt(child) in children.iter() {
             let score = scores.get_mut(*child).expect("where is it?");
-            product *= score.get();
+            product *= score.0;
             num_scorers += 1;
         }
 
-        // we can now need to modify the score based on the number of inputs
-        // see http://www.gdcvault.com/play/1021848/Building-a-Better-Centaur-AI
+        // we can apply some compensation for the fact that composite score will be reduced for scores
+        // with more inputs. See for example http://www.gdcvault.com/play/1021848/Building-a-Better-Centaur-AI
         if *apply_compensation && product < 1.0 {
             let mod_factor = 1.0 - 1.0 / (num_scorers as f32);
             let makeup = (1.0 - product) * mod_factor;

--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -288,7 +288,7 @@ Composite Scorer that takes any number of other Scorers and returns the product 
 is less than the threshold, it returns 0.
 
 The Scorer can also apply a compensation factor based on the number of Scores passed to it. This can be enabled by passing
-`true` to the `apply_compensation` function on the builder.
+`true` to the `use_compensation` method on the builder.
 
 ### Example
 
@@ -296,7 +296,7 @@ The Scorer can also apply a compensation factor based on the number of Scores pa
 Thinker::build()
     .when(
         ProductOfScorers::build(0.5)
-          .apply_compensation(true)
+          .use_compensation(true)
           .push(MyScorer)
           .push(MyOtherScorer),
         MyAction::build());


### PR DESCRIPTION
Adds a new composite scorer - `ProductOfScorers` that multiplies the scores from a given system together and returns the result if it is above the threshold. This is basically a slight modification on the `SumOfScorers` already in the library.

This scorer also provides optional compensation based on the number of scorers it calculates over. This is helpful because for scores between 0 and 1, the more scorers we multiply together the lower the resulting total is (i.e. 0.5*0.5 > 0.5*0.5*0.5). This compensation is based on a formula given in this talk http://www.gdcvault.com/play/1021848/Building-a-Better-Centaur-AI. You can see the effect of this compensation by comparing the lines in this graph https://www.desmos.com/calculator/uvuqwx04gp
