### PR TITLE
Implement MeasuredScorer and some initial measures

### DIFF
--- a/examples/custom_measure.rs
+++ b/examples/custom_measure.rs
@@ -1,0 +1,207 @@
+//! This example demonstrates how to build a custom measure and use that
+//! in a Thinker.
+
+use bevy::log::LogSettings;
+use bevy::prelude::*;
+use bevy::utils::tracing::{debug, trace};
+use big_brain::prelude::*;
+use big_brain::scorers::MeasuredScorer;
+
+// Lets define a custom measure. There are quite a few built-in ones in big-brain,
+// so we'll create a slightly useless Measure that sums together the weighted scores,
+// but weights get divided by the Scorer's index in the Vec.
+#[derive(Debug, Clone)]
+pub struct SumWithDecreasingWeightMeasure;
+
+impl Measure for SumWithDecreasingWeightMeasure {
+    fn calculate(&self, scores: Vec<(&Score, f32)>) -> f32 {
+        scores
+            .iter()
+            .enumerate()
+            .fold(0f32, |acc, (idx, (score, weight))| {
+                acc + score.get() * weight / (1.0 + idx as f32)
+            })
+    }
+}
+
+// We'll keep this example fairly simple, let's have Waffles and Pancakes, and
+// try to optimise our happiness based. Its like the thirst example but sweeter.
+#[derive(Component, Debug)]
+pub struct Pancakes(pub f32);
+
+#[derive(Component, Debug)]
+pub struct Waffles(pub f32);
+
+pub fn eat_dessert(time: Res<Time>, mut pancakes: Query<(&mut Pancakes, &mut Waffles)>) {
+    let delta_t = time.delta_seconds();
+
+    for (mut pancake, mut waffle) in pancakes.iter_mut() {
+        pancake.0 = (pancake.0 - delta_t).max(0.0);
+        waffle.0 = (waffle.0 - delta_t).max(0.0);
+
+        info!("Pancake: {}, waffle: {}", pancake.0, waffle.0);
+    }
+}
+
+// We have two actions, we can either eat pancakes or waffles, but not both, or....
+// no no no, let's keep this sensible. Speaking of "sensible", as these actions are
+// very similar we'll use generics to save writing them twice. We need a trait to
+// update the pancake/waffle state
+pub trait EatFood {
+    fn get(&self) -> f32;
+    fn eat(&mut self, amount: f32);
+}
+
+impl EatFood for Pancakes {
+    fn get(&self) -> f32 {
+        self.0
+    }
+
+    fn eat(&mut self, amount: f32) {
+        self.0 = (self.0 + amount).clamp(0.0, 100.0)
+    }
+}
+impl EatFood for Waffles {
+    fn get(&self) -> f32 {
+        self.0
+    }
+
+    fn eat(&mut self, amount: f32) {
+        self.0 = (self.0 + amount).clamp(0.0, 100.0)
+    }
+}
+
+// ok so now we can specify our actions
+#[derive(Clone, Component, Debug)]
+pub struct EatPancakes;
+
+#[derive(Clone, Component, Debug)]
+pub struct EatWaffles;
+
+fn eat_thing_action<
+    TActionMarker: std::fmt::Debug + Component,
+    TActorMarker: Component + EatFood,
+>(
+    time: Res<Time>,
+    mut items: Query<&mut TActorMarker>,
+    // We execute actions by querying for their associated Action Component
+    // (Drink in this case). You'll always need both Actor and ActionState.
+    mut query: Query<(&Actor, &mut ActionState, &TActionMarker, &ActionSpan)>,
+) {
+    for (Actor(actor), mut state, action_marker, span) in query.iter_mut() {
+        let _guard = span.span().enter();
+
+        if let Ok(mut item) = items.get_mut(*actor) {
+            match *state {
+                ActionState::Requested => {
+                    debug!("Time to eat something - {:?}", action_marker);
+                    *state = ActionState::Executing;
+                }
+                ActionState::Executing => {
+                    trace!("Eating {:?}", action_marker);
+
+                    item.eat(time.delta_seconds() * 5.0);
+
+                    if item.get() > 95.0 {
+                        debug!("Done eating {:?}", action_marker);
+                        *state = ActionState::Success;
+                    }
+                }
+                // All Actions should make sure to handle cancellations!
+                ActionState::Cancelled => {
+                    debug!(
+                        "Cancelled eating {:?}. Considering this a failure.",
+                        action_marker
+                    );
+                    *state = ActionState::Failure;
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+// Next we need to implement our Scorers, one for each of our Pancake and Waffle eating habits.
+#[derive(Clone, Component, Debug)]
+pub struct CravingPancakes;
+
+#[derive(Clone, Component, Debug)]
+pub struct CravingWaffles;
+
+// We can make our Scorer generic as well I guess?
+pub fn craving_food_scorer<
+    TScoreMarker: std::fmt::Debug + Component,
+    TActorMarker: Component + EatFood,
+>(
+    items: Query<&TActorMarker>,
+    mut query: Query<(&Actor, &mut Score), With<TScoreMarker>>,
+) {
+    for (Actor(actor), mut score) in &mut query {
+        if let Ok(item) = items.get(*actor) {
+            score.set((1.0 - item.get() / 100.0).clamp(0.0, 1.0));
+        }
+    }
+}
+
+// Let's set up our world
+pub fn init_entities(mut cmd: Commands) {
+    cmd.spawn()
+        .insert(Pancakes(50.0))
+        .insert(Waffles(50.0))
+        .insert(
+            Thinker::build()
+                .label("Hungry Thinker")
+                .picker(Highest)
+                // we use our custom measure here. The impact of the custom measure is that the
+                // pancakes should be down-weighted. This means despite this being listed first,
+                // all things being equal we should consume pancakes before waffles.
+                .when(
+                    MeasuredScorer::build(0.05)
+                        .label("waffles")
+                        .measure(SumWithDecreasingWeightMeasure)
+                        .push(CravingWaffles, 0.5)
+                        .push(CravingPancakes, 0.5),
+                    EatPancakes,
+                )
+                // we use the default measure here
+                .when(
+                    MeasuredScorer::build(0.05)
+                        .label("pancakes")
+                        .push(CravingPancakes, 0.5)
+                        .push(CravingWaffles, 0.5),
+                    EatPancakes,
+                ),
+        );
+}
+
+fn main() {
+    // Once all that's done, we just add our systems and off we go!
+    App::new()
+        .insert_resource(LogSettings {
+            // Use `RUST_LOG=big_brain=trace,thirst=trace cargo run --example
+            // custom_measure --features=trace` to see extra tracing output.
+            filter: "big_brain=debug,thirst=debug".to_string(),
+            ..Default::default()
+        })
+        .add_plugins(DefaultPlugins)
+        .add_plugin(BigBrainPlugin)
+        .add_startup_system(init_entities)
+        .add_system(eat_dessert)
+        .add_system_to_stage(
+            BigBrainStage::Actions,
+            eat_thing_action::<EatPancakes, Pancakes>,
+        )
+        .add_system_to_stage(
+            BigBrainStage::Actions,
+            eat_thing_action::<EatWaffles, Waffles>,
+        )
+        .add_system_to_stage(
+            BigBrainStage::Scorers,
+            craving_food_scorer::<CravingPancakes, Pancakes>,
+        )
+        .add_system_to_stage(
+            BigBrainStage::Scorers,
+            craving_food_scorer::<CravingWaffles, Waffles>,
+        )
+        .run();
+}

--- a/examples/custom_measure.rs
+++ b/examples/custom_measure.rs
@@ -95,17 +95,17 @@ fn eat_thing_action<
         if let Ok(mut item) = items.get_mut(*actor) {
             match *state {
                 ActionState::Requested => {
-                    info!("Time to eat something - {:?}", action_marker);
+                    info!("Time to {:?}", action_marker);
                     *state = ActionState::Executing;
                 }
                 ActionState::Executing => {
-                    debug!("Eating {:?}", action_marker);
+                    debug!("You should {:?}", action_marker);
 
                     item.eat(time.delta_seconds() * 5.0);
 
                     // we should stop at some eating pancakes at some point, unfortunately
                     if item.get() > 80.0 {
-                        info!("Done eating {:?}", action_marker);
+                        info!("You shouldn't {:?}", action_marker);
                         *state = ActionState::Success;
                     }
                 }
@@ -143,7 +143,7 @@ pub fn craving_food_scorer<
             // we don't want to get too full here, so lets say we only eat if we get below 0.5
             let current_food = item.get();
 
-            if current_food >= 0.5 {
+            if current_food >= 50.0 {
                 score.set(0.0);
             } else {
                 // if we're hungry let's get increasingly angry about it, so it increases
@@ -162,7 +162,7 @@ pub fn init_entities(mut cmd: Commands) {
         .insert(
             Thinker::build()
                 .label("Hungry Thinker")
-                .picker(Highest)
+                .picker(FirstToScore::new(0.5))
                 // we use our custom measure here. The impact of the custom measure is that the
                 // pancakes should be down-weighted. This means despite this being listed first,
                 // all things being equal we should consume pancakes before waffles.

--- a/examples/custom_measure.rs
+++ b/examples/custom_measure.rs
@@ -162,7 +162,7 @@ pub fn init_entities(mut cmd: Commands) {
                         .measure(SumWithDecreasingWeightMeasure)
                         .push(CravingWaffles, 0.5)
                         .push(CravingPancakes, 0.5),
-                    EatPancakes,
+                    EatWaffles,
                 )
                 // we use the default measure here
                 .when(

--- a/examples/custom_measure.rs
+++ b/examples/custom_measure.rs
@@ -25,7 +25,8 @@ impl Measure for SumWithDecreasingWeightMeasure {
 }
 
 // We'll keep this example fairly simple, let's have Waffles and Pancakes, and
-// try to optimise our happiness based. Its like the thirst example but sweeter.
+// try to optimise our happiness based on keeping our waffle and pancake level high.
+// Its kind of like the thirst example but sweeter.
 #[derive(Component, Debug)]
 pub struct Pancakes(pub f32);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,7 @@ impl Plugin for BigBrainPlugin {
             BigBrainStage::Scorers,
             SystemSet::new()
                 .with_system(scorers::fixed_score_system)
+                .with_system(scorers::measured_scorers_system)
                 .with_system(scorers::all_or_nothing_system)
                 .with_system(scorers::sum_of_scorers_system)
                 .with_system(scorers::product_of_scorers_system)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,7 @@ pub mod prelude {
     pub use super::BigBrainPlugin;
     pub use super::BigBrainStage;
     pub use actions::{ActionBuilder, ActionState, Concurrently, Steps};
+    pub use measures::{ChebyshevDistance, Measure, WeightedProduct, WeightedSum};
     pub use pickers::{FirstToScore, Highest, Picker};
     pub use scorers::{
         AllOrNothing, FixedScore, ProductOfScorers, Score, ScorerBuilder, SumOfScorers,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@ pub mod pickers;
 
 pub mod actions;
 pub mod choices;
+pub mod measures;
 pub mod scorers;
 pub mod thinker;
 
@@ -143,9 +144,10 @@ pub mod prelude {
     pub use actions::{ActionBuilder, ActionState, Concurrently, Steps};
     pub use pickers::{FirstToScore, Highest, Picker};
     pub use scorers::{
-        AllOrNothing, FixedScore, ProductOfScorers, Score, ScorerBuilder, SumOfScorers, WinningScorer,
+        AllOrNothing, FixedScore, ProductOfScorers, Score, ScorerBuilder, SumOfScorers,
+        WinningScorer,
     };
-    pub use thinker::{Actor, ActionEnt, ScorerEnt, Thinker, ThinkerBuilder};
+    pub use thinker::{ActionEnt, Actor, ScorerEnt, Thinker, ThinkerBuilder};
 }
 
 use bevy::prelude::*;

--- a/src/measures.rs
+++ b/src/measures.rs
@@ -13,9 +13,9 @@ pub trait Measure: std::fmt::Debug + Sync + Send {
 
 /// A measure that adds all the elements together and multiplies them by the weight
 #[derive(Debug, Clone)]
-pub struct WeightedSumMeasure;
+pub struct WeightedSum;
 
-impl Measure for WeightedSumMeasure {
+impl Measure for WeightedSum {
     fn calculate(&self, scores: Vec<(&Score, f32)>) -> f32 {
         scores
             .iter()
@@ -25,9 +25,9 @@ impl Measure for WeightedSumMeasure {
 
 /// A measure that multiplies all the elements together
 #[derive(Debug, Clone)]
-pub struct WeightedProductMeasure;
+pub struct WeightedProduct;
 
-impl Measure for WeightedProductMeasure {
+impl Measure for WeightedProduct {
     fn calculate(&self, scores: Vec<(&Score, f32)>) -> f32 {
         scores
             .iter()
@@ -38,12 +38,32 @@ impl Measure for WeightedProductMeasure {
 /// A measure that returns the max of the weighted child scares based on the one-dimensional
 /// (Chebychev Distance)[https://en.wikipedia.org/wiki/Chebyshev_distance]
 #[derive(Debug, Clone)]
-pub struct ChebyshevDistanceMeasure;
+pub struct ChebyshevDistance;
 
-impl Measure for ChebyshevDistanceMeasure {
+impl Measure for ChebyshevDistance {
     fn calculate(&self, scores: Vec<(&Score, f32)>) -> f32 {
         scores
             .iter()
             .fold(0f32, |best, (score, weight)| (score.0 * weight).max(best))
+    }
+}
+
+/// The default measure which uses
+#[derive(Debug, Clone, Default)]
+pub struct WeightedMeasure;
+
+impl Measure for WeightedMeasure {
+    fn calculate(&self, scores: Vec<(&Score, f32)>) -> f32 {
+        let wsum: f32 = scores.iter().map(|(_score, weight)| weight).sum();
+
+        if wsum == 0.0 {
+            0.0
+        } else {
+            scores
+                .iter()
+                .map(|(score, weight)| weight / wsum * score.get().powf(2.0))
+                .sum::<f32>()
+                .powf(1.0 / 2.0)
+        }
     }
 }

--- a/src/measures.rs
+++ b/src/measures.rs
@@ -1,0 +1,32 @@
+/*!
+ * A series of [Measures](https://en.wikipedia.org/wiki/Measure_(mathematics)) used to
+ * weight score.
+ */
+
+use crate::prelude::Score;
+
+/// A Measure trait describes a way to combine scores together
+pub trait Measure: std::fmt::Debug + Sync + Send {
+    /// Calculates a score from the child scores
+    fn calculate(&self, scores: Vec<&Score>) -> f32;
+}
+
+/// A basic measure that just adds all the elements together
+#[derive(Debug, Clone)]
+pub struct SumMeasure;
+
+impl Measure for SumMeasure {
+    fn calculate(&self, scores: Vec<&Score>) -> f32 {
+        scores.iter().fold(0f32, |acc, item| acc + item.0)
+    }
+}
+
+/// A basic measure that just multiplies all the elements together
+#[derive(Debug, Clone)]
+pub struct ProductMeasure;
+
+impl Measure for ProductMeasure {
+    fn calculate(&self, scores: Vec<&Score>) -> f32 {
+        scores.iter().fold(0f32, |acc, item| acc * item.0)
+    }
+}

--- a/src/measures.rs
+++ b/src/measures.rs
@@ -8,35 +8,42 @@ use crate::prelude::Score;
 /// A Measure trait describes a way to combine scores together
 pub trait Measure: std::fmt::Debug + Sync + Send {
     /// Calculates a score from the child scores
-    fn calculate(&self, scores: Vec<&Score>) -> f32;
-}
-
-/// A measure that adds all the elements together
-#[derive(Debug, Clone)]
-pub struct SumMeasure;
-
-impl Measure for SumMeasure {
-    fn calculate(&self, scores: Vec<&Score>) -> f32 {
-        scores.iter().fold(0f32, |acc, item| acc + item.0)
-    }
+    fn calculate(&self, inputs: Vec<(&Score, f32)>) -> f32;
 }
 
 /// A measure that adds all the elements together and multiplies them by the weight
 #[derive(Debug, Clone)]
-pub struct WeightedSumMeasure(pub f32);
+pub struct WeightedSumMeasure;
 
 impl Measure for WeightedSumMeasure {
-    fn calculate(&self, scores: Vec<&Score>) -> f32 {
-        scores.iter().fold(0f32, |acc, item| acc + item.0) * self.0
+    fn calculate(&self, scores: Vec<(&Score, f32)>) -> f32 {
+        scores
+            .iter()
+            .fold(0f32, |acc, (score, weight)| acc + score.0 * weight)
     }
 }
 
 /// A measure that multiplies all the elements together
 #[derive(Debug, Clone)]
-pub struct ProductMeasure;
+pub struct WeightedProductMeasure;
 
-impl Measure for ProductMeasure {
-    fn calculate(&self, scores: Vec<&Score>) -> f32 {
-        scores.iter().fold(0f32, |acc, item| acc * item.0)
+impl Measure for WeightedProductMeasure {
+    fn calculate(&self, scores: Vec<(&Score, f32)>) -> f32 {
+        scores
+            .iter()
+            .fold(0f32, |acc, (score, weight)| acc * score.0 * weight)
+    }
+}
+
+/// A measure that returns the max of the weighted child scares based on the one-dimensional
+/// (Chebychev Distance)[https://en.wikipedia.org/wiki/Chebyshev_distance]
+#[derive(Debug, Clone)]
+pub struct ChebyshevDistanceMeasure;
+
+impl Measure for ChebyshevDistanceMeasure {
+    fn calculate(&self, scores: Vec<(&Score, f32)>) -> f32 {
+        scores
+            .iter()
+            .fold(0f32, |best, (score, weight)| (score.0 * weight).max(best))
     }
 }

--- a/src/measures.rs
+++ b/src/measures.rs
@@ -11,7 +11,7 @@ pub trait Measure: std::fmt::Debug + Sync + Send {
     fn calculate(&self, scores: Vec<&Score>) -> f32;
 }
 
-/// A basic measure that just adds all the elements together
+/// A measure that adds all the elements together
 #[derive(Debug, Clone)]
 pub struct SumMeasure;
 
@@ -21,7 +21,17 @@ impl Measure for SumMeasure {
     }
 }
 
-/// A basic measure that just multiplies all the elements together
+/// A measure that adds all the elements together and multiplies them by the weight
+#[derive(Debug, Clone)]
+pub struct WeightedSumMeasure(pub f32);
+
+impl Measure for WeightedSumMeasure {
+    fn calculate(&self, scores: Vec<&Score>) -> f32 {
+        scores.iter().fold(0f32, |acc, item| acc + item.0) * self.0
+    }
+}
+
+/// A measure that multiplies all the elements together
 #[derive(Debug, Clone)]
 pub struct ProductMeasure;
 

--- a/src/pickers.rs
+++ b/src/pickers.rs
@@ -56,7 +56,7 @@ Picker that chooses the `Choice` with the highest non-zero [`Score`], and the fi
 
 ```no_run
 Thinker::build()
-    .picker(HighestThenFirst)
+    .picker(Highest)
     // .when(...)
 ```
  */

--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -648,8 +648,7 @@ pub struct MeasuredScorerBuilder {
 }
 
 impl MeasuredScorerBuilder {
-    /// To account for the fact that the total score will be reduced for scores with more inputs,
-    /// we can optionally apply a compensation factor by calling this and passing `true`
+    /// Sets the measure to be used to combine the child scorers
     pub fn measure(mut self, measure: impl Measure + 'static) -> Self {
         self.measure = Arc::new(measure);
         self

--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -10,7 +10,7 @@ use bevy::utils::tracing::trace;
 
 use crate::{
     evaluators::Evaluator,
-    measures::{Measure, WeightedSumMeasure},
+    measures::{Measure, WeightedMeasure},
     thinker::{Actor, Scorer, ScorerSpan},
 };
 
@@ -759,7 +759,7 @@ impl MeasuredScorer {
     pub fn build(threshold: f32) -> MeasuredScorerBuilder {
         MeasuredScorerBuilder {
             threshold,
-            measure: Arc::new(WeightedSumMeasure),
+            measure: Arc::new(WeightedMeasure),
             scorers: Vec::new(),
             label: None,
         }
@@ -822,6 +822,14 @@ impl MeasuredScorerBuilder {
 
     pub fn push(mut self, scorer: impl ScorerBuilder + 'static, weight: f32) -> Self {
         self.scorers.push((Arc::new(scorer), weight));
+        self
+    }
+
+    /**
+     * Set a label for this ScorerBuilder.
+     */
+    pub fn label(mut self, label: impl AsRef<str>) -> Self {
+        self.label = Some(label.as_ref().into());
         self
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/zkat/big-brain/issues/15, this re-introduces weighting and measures. 

`MeasureScorers` can be created using the following syntax

```rust
MeasuredScorer::build().measure(ProductMeasure)
```

The scorer defaults to `SumMeasure`.

I'd prefer to use `impl Iterator<Item = &'a Score>` for `calculate`, however it seems this isn't compatible with storing `Arc<dyn Measure>`/`Box<dyn Measure>`. So for now there is an annoying `collect` in the system.

I'm putting this up as a draft for discussion, as I'm not 100% sure I have replicated what you had in mind, especially for some of the more detailed/mathematical measures.