### PR TITLE
Add derive macros for Action and Scorer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,11 @@ categories = ["game-development"]
 repository = "https://github.com/zkat/big-brain"
 homepage = "https://github.com/zkat/big-brain"
 
+[workspace]
+
 [dependencies]
 bevy = { version = "0.9.0", default-features = false }
+big-brain-derive = { version = "0.1.0", path = "./derive" }
 
 [dev-dependencies]
 bevy = { version = "0.9.0", default-features = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ homepage = "https://github.com/zkat/big-brain"
 
 [dependencies]
 bevy = { version = "0.9.0", default-features = false }
-big-brain-derive = { version = "0.1.0", path = "./derive" }
+big-brain-derive = { version = "0.2.1", path = "./derive" }
 
 [dev-dependencies]
 bevy = { version = "0.9.0", default-features = true }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ actual behavior.
 use bevy::prelude::*;
 use big_brain::prelude::*;
 
-#[derive(Debug, Clone, Component)]
+#[derive(Debug, Clone, Component, ScorerBuilder)]
+#[scorer_label = "Thirsty"]
 pub struct Thirsty;
 
 pub fn thirsty_scorer_system(
@@ -65,7 +66,8 @@ state of the state machine.
 use bevy::prelude::*;
 use big_brain::prelude::*;
 
-#[derive(Debug, Clone, Component)]
+#[derive(Debug, Clone, Component, ActionBuilder)]
+#[action_label = "Drink"]
 pub struct Drink;
 
 fn drink_action_system(

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "big-brain-derive"
+version = "0.1.0"
+authors = ["Kat Marchán <kzm@zkat.tech>"]
+description = "Procedural macros to simplify implementation of Big Brain traits"
+documentation = "https://docs.rs/big-brain-derive"
+homepage = "https://github.com/zkat/big-brain"
+repository = "https://github.com/zkat/big-brain"
+keywords = ["utility-ai", "bevy", "ai", "ecs"]
+categories = ["game-development"]
+license = "Apache-2.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[features]
+
+[dependencies]
+proc-macro2 = "1.0"
+syn = { version = "1.0", features = ["parsing"]}
+quote = "1.0"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "big-brain-derive"
-version = "0.1.0"
+version = "0.2.1"
 authors = ["Kat Marchán <kzm@zkat.tech>"]
 description = "Procedural macros to simplify implementation of Big Brain traits"
 documentation = "https://docs.rs/big-brain-derive"

--- a/derive/src/action.rs
+++ b/derive/src/action.rs
@@ -32,11 +32,11 @@ fn get_label(input: &DeriveInput) -> Option<LitStr> {
             let path = meta_name_value.path;
             let lit = meta_name_value.lit;
             if let Some(ident) = path.get_ident() {
-                if ident == "label" {
+                if ident == "action_label" {
                     if let Lit::Str(lit_str) = lit {
                         label = Some(lit_str);
                     } else {
-                        panic!("Must specify a string for the `label` attribute")
+                        panic!("Must specify a string for the `action_label` attribute")
                     }
                 }
             }

--- a/derive/src/action.rs
+++ b/derive/src/action.rs
@@ -1,0 +1,70 @@
+//! Derive ActionBuilder on a given struct
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput, Ident, Lit, Meta, LitStr};
+
+
+/// Derive ActionBuilder on a struct that implements Component + Clone
+pub fn action_builder_impl(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let label = get_label(&input);
+
+    let component_name = input.ident;
+    let build_method = build_method(&component_name);
+    let label_method = label_method(label);
+
+    let gen = quote!{
+        impl ActionBuilder for #component_name {
+            #build_method
+            #label_method
+        }
+    };
+
+    proc_macro::TokenStream::from(gen)
+}
+
+fn get_label(input: &DeriveInput) -> Option<LitStr> {
+    let mut label: Option<LitStr> = None;
+    let attrs = &input.attrs;
+    for option in attrs {
+        let option = option.parse_meta().unwrap();
+        if let Meta::NameValue(meta_name_value) = option {
+            let path = meta_name_value.path;
+            let lit = meta_name_value.lit;
+            if let Some(ident) = path.get_ident() {
+                if ident == "label" {
+                    if let Lit::Str(lit_str) = lit {
+                        label = Some(lit_str);
+                    } else {
+                        panic!("Must specify a string for the `label` attribute")
+                    }
+                }
+            }
+        }
+    }
+    label
+}
+
+fn build_method(
+    component_name: &Ident,
+) -> TokenStream {
+    quote! {
+        fn build(&self, cmd: &mut Commands, action: Entity, _actor: Entity) {
+            cmd.entity(action).insert(#component_name::clone(self));
+        }
+    }
+}
+
+fn label_method(label_option: Option<LitStr>) -> TokenStream {
+    let inner = if let Some(label) = label_option {
+        quote!{Some(#label)}
+    } else {
+        quote!{None}
+    };
+    quote! {
+        fn label(&self) -> Option<&str> {
+            #inner
+        }
+    }
+}

--- a/derive/src/action.rs
+++ b/derive/src/action.rs
@@ -1,8 +1,7 @@
 //! Derive ActionBuilder on a given struct
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput, Ident, Lit, Meta, LitStr};
-
+use syn::{parse_macro_input, DeriveInput, Ident, Lit, LitStr, Meta};
 
 /// Derive ActionBuilder on a struct that implements Component + Clone
 pub fn action_builder_impl(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -14,7 +13,7 @@ pub fn action_builder_impl(input: proc_macro::TokenStream) -> proc_macro::TokenS
     let build_method = build_method(&component_name);
     let label_method = label_method(label);
 
-    let gen = quote!{
+    let gen = quote! {
         impl ActionBuilder for #component_name {
             #build_method
             #label_method
@@ -46,9 +45,7 @@ fn get_label(input: &DeriveInput) -> Option<LitStr> {
     label
 }
 
-fn build_method(
-    component_name: &Ident,
-) -> TokenStream {
+fn build_method(component_name: &Ident) -> TokenStream {
     quote! {
         fn build(&self, cmd: &mut Commands, action: Entity, _actor: Entity) {
             cmd.entity(action).insert(#component_name::clone(self));
@@ -58,9 +55,9 @@ fn build_method(
 
 fn label_method(label_option: Option<LitStr>) -> TokenStream {
     let inner = if let Some(label) = label_option {
-        quote!{Some(#label)}
+        quote! {Some(#label)}
     } else {
-        quote!{None}
+        quote! {None}
     };
     quote! {
         fn label(&self) -> Option<&str> {

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -7,13 +7,13 @@ use action::action_builder_impl;
 use scorer::scorer_builder_impl;
 
 /// Derives ActionBuilder for a struct that implements Component + Clone
-#[proc_macro_derive(ActionBuilder, attributes(label))]
+#[proc_macro_derive(ActionBuilder, attributes(action_label))]
 pub fn action_builder_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     action_builder_impl(input)
 }
 
 /// Derives ScorerBuilder for a struct that implements Component + Clone
-#[proc_macro_derive(ScorerBuilder, attributes(label))]
+#[proc_macro_derive(ScorerBuilder, attributes(scorer_label))]
 pub fn scorer_builder_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     scorer_builder_impl(input)
 }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,0 +1,20 @@
+//! Big Brain Derive
+//! Procedural macros to simplify the implementation of Big Brain traits
+mod action;
+mod scorer;
+
+use action::action_builder_impl;
+use scorer::scorer_builder_impl;
+
+
+/// Derives ActionBuilder for a struct that implements Component + Clone
+#[proc_macro_derive(ActionBuilder, attributes(label))]
+pub fn action_builder_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    action_builder_impl(input)
+}
+
+/// Derives ScorerBuilder for a struct that implements Component + Clone
+#[proc_macro_derive(ScorerBuilder, attributes(label))]
+pub fn scorer_builder_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    scorer_builder_impl(input)
+}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -6,7 +6,6 @@ mod scorer;
 use action::action_builder_impl;
 use scorer::scorer_builder_impl;
 
-
 /// Derives ActionBuilder for a struct that implements Component + Clone
 #[proc_macro_derive(ActionBuilder, attributes(label))]
 pub fn action_builder_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {

--- a/derive/src/scorer.rs
+++ b/derive/src/scorer.rs
@@ -32,11 +32,11 @@ fn get_label(input: &DeriveInput) -> Option<LitStr> {
             let path = meta_name_value.path;
             let lit = meta_name_value.lit;
             if let Some(ident) = path.get_ident() {
-                if ident == "label" {
+                if ident == "scorer_label" {
                     if let Lit::Str(lit_str) = lit {
                         label = Some(lit_str);
                     } else {
-                        panic!("Must specify a string for the `label` attribute")
+                        panic!("Must specify a string for the `scorer_label` attribute")
                     }
                 }
             }

--- a/derive/src/scorer.rs
+++ b/derive/src/scorer.rs
@@ -1,8 +1,7 @@
 //! Derive ScorerBuilder on a given struct
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput, Ident, Lit, Meta, LitStr};
-
+use syn::{parse_macro_input, DeriveInput, Ident, Lit, LitStr, Meta};
 
 /// Derive ScorerBuilder on a struct that implements Component + Clone
 pub fn scorer_builder_impl(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
@@ -14,7 +13,7 @@ pub fn scorer_builder_impl(input: proc_macro::TokenStream) -> proc_macro::TokenS
     let build_method = build_method(&component_name);
     let label_method = label_method(label);
 
-    let gen = quote!{
+    let gen = quote! {
         impl ScorerBuilder for #component_name {
             #build_method
             #label_method
@@ -46,9 +45,7 @@ fn get_label(input: &DeriveInput) -> Option<LitStr> {
     label
 }
 
-fn build_method(
-    component_name: &Ident,
-) -> TokenStream {
+fn build_method(component_name: &Ident) -> TokenStream {
     quote! {
         fn build(&self, cmd: &mut Commands, scorer: Entity, _actor: Entity) {
             cmd.entity(scorer).insert(#component_name::clone(self));
@@ -58,9 +55,9 @@ fn build_method(
 
 fn label_method(label_option: Option<LitStr>) -> TokenStream {
     let inner = if let Some(label) = label_option {
-        quote!{Some(#label)}
+        quote! {Some(#label)}
     } else {
-        quote!{None}
+        quote! {None}
     };
     quote! {
         fn label(&self) -> Option<&str> {

--- a/derive/src/scorer.rs
+++ b/derive/src/scorer.rs
@@ -1,0 +1,70 @@
+//! Derive ScorerBuilder on a given struct
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput, Ident, Lit, Meta, LitStr};
+
+
+/// Derive ScorerBuilder on a struct that implements Component + Clone
+pub fn scorer_builder_impl(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let label = get_label(&input);
+
+    let component_name = input.ident;
+    let build_method = build_method(&component_name);
+    let label_method = label_method(label);
+
+    let gen = quote!{
+        impl ScorerBuilder for #component_name {
+            #build_method
+            #label_method
+        }
+    };
+
+    proc_macro::TokenStream::from(gen)
+}
+
+fn get_label(input: &DeriveInput) -> Option<LitStr> {
+    let mut label: Option<LitStr> = None;
+    let attrs = &input.attrs;
+    for option in attrs {
+        let option = option.parse_meta().unwrap();
+        if let Meta::NameValue(meta_name_value) = option {
+            let path = meta_name_value.path;
+            let lit = meta_name_value.lit;
+            if let Some(ident) = path.get_ident() {
+                if ident == "label" {
+                    if let Lit::Str(lit_str) = lit {
+                        label = Some(lit_str);
+                    } else {
+                        panic!("Must specify a string for the `label` attribute")
+                    }
+                }
+            }
+        }
+    }
+    label
+}
+
+fn build_method(
+    component_name: &Ident,
+) -> TokenStream {
+    quote! {
+        fn build(&self, cmd: &mut Commands, scorer: Entity, _actor: Entity) {
+            cmd.entity(scorer).insert(#component_name::clone(self));
+        }
+    }
+}
+
+fn label_method(label_option: Option<LitStr>) -> TokenStream {
+    let inner = if let Some(label) = label_option {
+        quote!{Some(#label)}
+    } else {
+        quote!{None}
+    };
+    quote! {
+        fn label(&self) -> Option<&str> {
+            #inner
+        }
+    }
+}

--- a/examples/custom_measure.rs
+++ b/examples/custom_measure.rs
@@ -73,10 +73,10 @@ impl EatFood for Waffles {
 }
 
 // ok so now we can specify our actions
-#[derive(Clone, Component, Debug)]
+#[derive(Clone, Component, Debug, ActionBuilder)]
 pub struct EatPancakes;
 
-#[derive(Clone, Component, Debug)]
+#[derive(Clone, Component, Debug, ActionBuilder)]
 pub struct EatWaffles;
 
 fn eat_thing_action<
@@ -124,10 +124,10 @@ fn eat_thing_action<
 }
 
 // Next we need to implement our Scorers, one for each of our Pancake and Waffle eating habits.
-#[derive(Clone, Component, Debug)]
+#[derive(Clone, Component, Debug, ScorerBuilder)]
 pub struct CravingPancakes;
 
-#[derive(Clone, Component, Debug)]
+#[derive(Clone, Component, Debug, ScorerBuilder)]
 pub struct CravingWaffles;
 
 // We can make our Scorer generic as well I guess?

--- a/examples/one_off.rs
+++ b/examples/one_off.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use bevy::utils::tracing::{debug, trace};
 use big_brain::prelude::*;
 
-#[derive(Clone, Component, Debug)]
+#[derive(Clone, Component, Debug, ActionBuilder)]
 struct OneOff;
 
 fn one_off_action_system(mut query: Query<(&mut ActionState, &ActionSpan), With<OneOff>>) {

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -52,7 +52,7 @@ pub fn thirst_system(time: Res<Time>, mut thirsts: Query<&mut Thirst>) {
 }
 
 /// An action where the actor moves to the closest water source
-#[derive(Clone, Component, Debug)]
+#[derive(Clone, Component, Debug, ActionBuilder)]
 pub struct MoveToWaterSource {
     // The movement speed of the actor.
     speed: f32,
@@ -147,7 +147,7 @@ fn find_closest_water_source(
 }
 
 /// A simple action: the actor's thirst shall decrease, but only if they are near a water source.
-#[derive(Clone, Component, Debug)]
+#[derive(Clone, Component, Debug, ActionBuilder)]
 pub struct Drink {
     per_second: f32,
 }
@@ -217,7 +217,7 @@ fn drink_action_system(
 }
 
 // Scorers are the same as in the thirst example.
-#[derive(Clone, Component, Debug)]
+#[derive(Clone, Component, Debug, ScorerBuilder)]
 pub struct Thirsty;
 
 pub fn thirsty_scorer_system(

--- a/examples/thirst.rs
+++ b/examples/thirst.rs
@@ -43,11 +43,12 @@ pub fn thirst_system(time: Res<Time>, mut thirsts: Query<&mut Thirst>) {
 // These actions will be spawned and queued by the game engine when their
 // conditions trigger (we'll configure what these are later).
 //
-// NOTE: In this example, we're not implementing ActionBuilder ourselves, but
-// instead just relying on the blanket implementation for anything that
-// implements Clone. So, the Clone derive matters here. This is enough in most
-// cases.
-#[derive(Clone, Component, Debug)]
+// In most cases, the ActionBuilder just attaches the Action component to the
+// actor entity. In this case, you can use the derive macro `ActionBuilder`
+// to make your Action Component implement the ActionBuilder trait.
+// You need your type to implement Clone and Debug (necessary for ActionBuilder)
+#[derive(Clone, Component, Debug, ActionBuilder)]
+#[label = "DrinkAction"]
 pub struct Drink {
     until: f32,
     per_second: f32,
@@ -100,10 +101,12 @@ fn drink_action_system(
 // run in the background, calculating a "Score" value, which is what Big Brain
 // will use to pick which Actions to execute.
 //
-// Just like with Actions, there's two pieces to this: the Scorer and the
-// ScorerBuilder. And just like with Actions, there's a blanket implementation
-// for Clone, so we only need the Component here.
-#[derive(Clone, Component, Debug)]
+// Just like with Actions, there is a distinction between Scorer components
+// and the ScorerBuilder which will attach those components to the Actor entity.
+//
+// Again, in most cases, you can use the `ScorerBuilder` derive macro to make your
+// Scorer Component act as a ScorerBuilder. You need it to implement Clone and Debug.
+#[derive(Clone, Component, Debug, ScorerBuilder)]
 pub struct Thirsty;
 
 // Looks familiar? It's a lot like Actions!

--- a/examples/thirst.rs
+++ b/examples/thirst.rs
@@ -48,7 +48,7 @@ pub fn thirst_system(time: Res<Time>, mut thirsts: Query<&mut Thirst>) {
 // to make your Action Component implement the ActionBuilder trait.
 // You need your type to implement Clone and Debug (necessary for ActionBuilder)
 #[derive(Clone, Component, Debug, ActionBuilder)]
-#[label = "DrinkAction"]
+#[action_label = "DrinkAction"]
 pub struct Drink {
     until: f32,
     per_second: f32,

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -86,7 +86,7 @@ pub trait ActionBuilder: std::fmt::Debug + Send + Sync {
 
     ```no_run
     #[derive(Debug, Clone, Component, ActionBuilder)]
-    #[label = "MyActionLabel"]
+    #[action_label = "MyActionLabel"]
     struct MyAction;
     ```
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -114,7 +114,6 @@ pub trait ActionBuilder: std::fmt::Debug + Send + Sync {
     }
 }
 
-
 /**
  * Spawns a new Action Component, using the given ActionBuilder. This is useful when you're doing things like writing composite Actions.
  */

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -76,16 +76,17 @@ pub trait ActionBuilder: std::fmt::Debug + Send + Sync {
     MUST insert your concrete Action component into the Scorer [`Entity`], using
      `cmd`. You _may_ use `actor`, but it's perfectly normal to just ignore it.
 
-    Note that this method is automatically implemented for any Components that
-    implement Clone, so you don't need to define it yourself unless you want
-    more complex parameterization of your Actions.
+    In most cases, your `ActionBuilder` and `Action` can be the same type.
+    The only requirement is that your struct implements `Debug`, `Component, `Clone`.
+    You can then use the derive macro `ActionBuilder` to turn your struct into a `ActionBuilder`
 
     ### Example
 
-    Using `Clone` (the easy way):
+    Using the derive macro (the easy way):
 
     ```no_run
-    #[derive(Debug, Clone, Component)]
+    #[derive(Debug, Clone, Component, ActionBuilder)]
+    #[label = "MyActionLabel"]
     struct MyAction;
     ```
 
@@ -113,14 +114,6 @@ pub trait ActionBuilder: std::fmt::Debug + Send + Sync {
     }
 }
 
-impl<T> ActionBuilder for T
-where
-    T: Component + Clone + std::fmt::Debug + Send + Sync,
-{
-    fn build(&self, cmd: &mut Commands, action: Entity, _actor: Entity) {
-        cmd.entity(action).insert(T::clone(self));
-    }
-}
 
 /**
  * Spawns a new Action Component, using the given ActionBuilder. This is useful when you're doing things like writing composite Actions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,8 @@ actual behavior.
 use bevy::prelude::*;
 use big_brain::prelude::*;
 
-#[derive(Debug, Clone, Component)]
+#[derive(Debug, Clone, Component, ScorerBuilder)]
+#[scorer_label = "Thirsty"]
 pub struct Thirsty;
 
 pub fn thirsty_scorer_system(
@@ -60,7 +61,8 @@ state of the state machine.
 use bevy::prelude::*;
 use big_brain::prelude::*;
 
-#[derive(Debug, Clone, Component)]
+#[derive(Debug, Clone, Component, ActionBuilder)]
+#[action_label = "Drink"]
 pub struct Drink;
 
 fn drink_action_system(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,10 +139,10 @@ pub mod prelude {
     */
     use super::*;
 
-    pub use big_brain_derive::{ScorerBuilder, ActionBuilder};
     pub use super::BigBrainPlugin;
     pub use super::BigBrainStage;
     pub use actions::{ActionBuilder, ActionState, Concurrently, Steps};
+    pub use big_brain_derive::{ActionBuilder, ScorerBuilder};
     pub use measures::{ChebyshevDistance, Measure, WeightedProduct, WeightedSum};
     pub use pickers::{FirstToScore, Highest, Picker};
     pub use scorers::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,7 @@ pub mod prelude {
     */
     use super::*;
 
+    pub use big_brain_derive::{ScorerBuilder, ActionBuilder};
     pub use super::BigBrainPlugin;
     pub use super::BigBrainStage;
     pub use actions::{ActionBuilder, ActionState, Concurrently, Steps};

--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -63,7 +63,7 @@ pub trait ScorerBuilder: std::fmt::Debug + Sync + Send {
 
     ```no_run
     #[derive(Debug, Clone, Component, ScorerBuilder)]
-    #[label = "MyScorerLabel"]
+    #[scorer_label = "MyScorerLabel"]
     struct MyScorer;
     ```
 

--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -53,16 +53,17 @@ pub trait ScorerBuilder: std::fmt::Debug + Sync + Send {
     MUST insert your concrete Scorer component into the Scorer [`Entity`], using
      `cmd`. You _may_ use `actor`, but it's perfectly normal to just ignore it.
 
-    Note that this method is automatically implemented for any Components that
-    implement Clone, so you don't need to define it yourself unless you want
-    more complex parameterization of your Actions.
+    In most cases, your `ScorerBuilder` and `Scorer` can be the same type.
+    The only requirement is that your struct implements `Debug`, `Component, `Clone`.
+    You can then use the derive macro `ScorerBuilder` to turn your struct into a `ScorerBuilder`
 
     ### Example
 
-    Using `Clone` (the easy way):
+    Using the derive macro (the easy way):
 
     ```no_run
-    #[derive(Debug, Clone, Component)]
+    #[derive(Debug, Clone, Component, ScorerBuilder)]
+    #[label = "MyScorerLabel"]
     struct MyScorer;
     ```
 
@@ -107,15 +108,6 @@ pub fn spawn_scorer<T: ScorerBuilder + ?Sized>(
     std::mem::drop(_guard);
     cmd.entity(scorer_ent).insert(span);
     scorer_ent
-}
-
-impl<T> ScorerBuilder for T
-where
-    T: Component + Clone + std::fmt::Debug + Send + Sync,
-{
-    fn build(&self, cmd: &mut Commands, action: Entity, _actor: Entity) {
-        cmd.entity(action).insert(T::clone(self));
-    }
 }
 
 /**

--- a/tests/derive_action.rs
+++ b/tests/derive_action.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use big_brain::prelude::*;
 
 #[derive(Debug, Clone, Component, ActionBuilder)]
-#[label = "MyLabel"]
+#[action_label = "MyLabel"]
 pub struct MyAction;
 
 #[test]

--- a/tests/derive_action.rs
+++ b/tests/derive_action.rs
@@ -1,9 +1,8 @@
 use bevy::prelude::*;
 use big_brain::prelude::*;
 
-
 #[derive(Debug, Clone, Component, ActionBuilder)]
-#[label="MyLabel"]
+#[label = "MyLabel"]
 pub struct MyAction;
 
 #[test]

--- a/tests/derive_action.rs
+++ b/tests/derive_action.rs
@@ -1,0 +1,13 @@
+use bevy::prelude::*;
+use big_brain::prelude::*;
+
+
+#[derive(Debug, Clone, Component, ActionBuilder)]
+#[label="MyLabel"]
+pub struct MyAction;
+
+#[test]
+fn check_macro() {
+    let action = MyAction;
+    assert_eq!(action.label(), Some("MyLabel"))
+}

--- a/tests/derive_scorer.rs
+++ b/tests/derive_scorer.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use big_brain::prelude::*;
 
 #[derive(Debug, Clone, Component, ScorerBuilder)]
-#[label = "MyLabel"]
+#[scorer_label = "MyLabel"]
 pub struct MyScorer;
 
 #[test]

--- a/tests/derive_scorer.rs
+++ b/tests/derive_scorer.rs
@@ -1,9 +1,8 @@
 use bevy::prelude::*;
 use big_brain::prelude::*;
 
-
 #[derive(Debug, Clone, Component, ScorerBuilder)]
-#[label="MyLabel"]
+#[label = "MyLabel"]
 pub struct MyScorer;
 
 #[test]

--- a/tests/derive_scorer.rs
+++ b/tests/derive_scorer.rs
@@ -1,0 +1,15 @@
+use bevy::prelude::*;
+use big_brain::prelude::*;
+
+
+#[derive(Debug, Clone, Component, ScorerBuilder)]
+#[label="MyLabel"]
+pub struct MyScorer;
+
+#[test]
+fn check_macro() {
+    // TODO: how to make sure that the struct implements Component and Clone?
+
+    let scorer = MyScorer;
+    assert_eq!(scorer.label(), Some("MyLabel"))
+}


### PR DESCRIPTION
PR for https://github.com/zkat/big-brain/issues/62 

- I think it will be clearer for users to explicitly add `ActionBuilder` / `ScorerBuilder`; it points them to the fact that there is a distinction between `Action` and `ActionBuilder` (which is kind of confusing at first).
- It also provides an easy way to add a Label for an Action or a Scorer