### PR TITLE
Add set_unchecked method to Score

### DIFF
--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -37,7 +37,9 @@ impl Score {
     }
 
     /// Set the `Score`'s value. Allows values outside the range `0.0..=1.0`
-    /// Note: it is up to you to make sure your scorers are using the same units!
+    /// WARNING: `Scorer`s are significantly harder to compose when there
+    /// isn't a set scale. Avoid using unless it's not feasible to rescale
+    /// and use `set` instead.
     pub fn set_unchecked(&mut self, value: f32) {
         self.0 = value;
     }

--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -35,6 +35,12 @@ impl Score {
         }
         self.0 = value;
     }
+
+    /// Set the `Score`'s value. Allows values outside the range `0.0..=1.0`
+    /// Note: it is up to you to make sure your scorers are using the same units!
+    pub fn set_unchecked(&mut self, value: f32) {
+        self.0 = value;
+    }
 }
 
 /// Trait that must be defined by types in order to be `ScorerBuilder`s.


### PR DESCRIPTION
In some cases it can be useful to be able to represent scores outside the [0,1] range, especially when it is difficult to calculate the minimum and maximum values of a Scorer, or you want one scorer to be able to dominate in certain scenarios. This PR adds a `set_unchecked` method to Score to accommodate this.

I saw some previous discussion on this in #36 , but I think it's good to give people the option. I've only been using big-brain for a few days, so feel free to ignore my opinion.