### PR TITLE
Update to bevy 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ homepage = "https://github.com/zkat/big-brain"
 [workspace]
 
 [dependencies]
-bevy = { version = "0.10", default-features = false }
+bevy = { version = "0.11", default-features = false }
 big-brain-derive = { version = "=0.17.0", path = "./derive" }
 
 [dev-dependencies]
-bevy = { version = "0.10", default-features = true }
+bevy = { version = "0.11", default-features = true }
 rand = { version = "0.8.5", features = ["small_rng"] }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -117,11 +117,13 @@ Once all that's done, we just add our systems and off we go!
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(BigBrainPlugin)
-        .add_startup_system(init_entities)
-        .add_system(thirst_system)
-        .add_system_to_stage(BigBrainStage::Actions, drink_action_system)
-        .add_system_to_stage(BigBrainStage::Scorers, thirsty_scorer_system)
+        .add_plugins(BigBrainPlugin::new(PreUpdate))
+        .add_systems(Startup, init_entities)
+        .add_systems(Update, thirst_system)
+        .add_systems(PreUpdate, (
+            drink_action_system.in_set(BigBrainSet::Actions),
+            thirsty_scorer_system.in_set(BigBrainSet::Scorers),
+        ))
         .run();
 }
 ```

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ fn main() {
 
 #### bevy version
 
-The current version of `big-brain` is compatible with `bevy` 0.9.0.
+The current version of `big-brain` is compatible with `bevy` 0.11.0.
 
 #### Contributing
 

--- a/examples/concurrent.rs
+++ b/examples/concurrent.rs
@@ -133,9 +133,14 @@ fn main() {
             filter: "big_brain=warn,concurrent=debug".to_string(),
             ..default()
         }))
-        .add_plugin(BigBrainPlugin)
-        .add_startup_system(init_entities)
-        .add_system(guess_number_action.in_set(BigBrainSet::Actions))
-        .add_system(dummy_scorer_system.in_set(BigBrainSet::Scorers))
+        .add_plugins(BigBrainPlugin::new(PreUpdate))
+        .add_systems(Startup, init_entities)
+        .add_systems(
+            PreUpdate,
+            (
+                guess_number_action.in_set(BigBrainSet::Actions),
+                dummy_scorer_system.in_set(BigBrainSet::Scorers),
+            ),
+        )
         .run();
 }

--- a/examples/custom_measure.rs
+++ b/examples/custom_measure.rs
@@ -193,10 +193,11 @@ fn main() {
             filter: "big_brain=debug,custom_measure=debug".to_string(),
             ..default()
         }))
-        .add_plugin(BigBrainPlugin)
-        .add_startup_system(init_entities)
-        .add_system(eat_dessert)
+        .add_plugins(BigBrainPlugin::new(PreUpdate))
+        .add_systems(Startup, init_entities)
+        .add_systems(Update, eat_dessert)
         .add_systems(
+            PreUpdate,
             (
                 eat_thing_action::<EatPancakes, Pancakes>,
                 eat_thing_action::<EatWaffles, Waffles>,
@@ -204,6 +205,7 @@ fn main() {
                 .in_set(BigBrainSet::Actions),
         )
         .add_systems(
+            PreUpdate,
             (
                 craving_food_scorer::<CravingPancakes, Pancakes>,
                 craving_food_scorer::<CravingWaffles, Waffles>,

--- a/examples/one_off.rs
+++ b/examples/one_off.rs
@@ -76,12 +76,15 @@ fn main() {
             filter: "big_brain=debug,one_off=debug".to_string(),
             ..default()
         }))
-        .add_plugin(BigBrainPlugin)
-        .add_startup_system(init_entities)
-        .add_system(thirst_system)
-        // Big Brain has specific stages for Scorers and Actions. If
+        .add_plugins(BigBrainPlugin::new(PreUpdate))
+        .add_systems(Startup, init_entities)
+        .add_systems(Update, thirst_system)
+        // Big Brain has specific sets for Scorers and Actions. If
         // determinism matters a lot to you, you should add your action and
         // scorer systems to these stages.
-        .add_system(one_off_action_system.in_set(BigBrainSet::Actions))
+        .add_systems(
+            PreUpdate,
+            one_off_action_system.in_set(BigBrainSet::Actions),
+        )
         .run();
 }

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -286,12 +286,13 @@ fn main() {
             filter: "big_brain=debug,sequence=debug".to_string(),
             ..default()
         }))
-        .add_plugin(BigBrainPlugin)
-        .add_startup_system(init_entities)
-        .add_system(thirst_system)
+        .add_plugins(BigBrainPlugin::new(PreUpdate))
+        .add_systems(Startup, init_entities)
+        .add_systems(Update, thirst_system)
         .add_systems(
+            PreUpdate,
             (drink_action_system, move_to_water_source_action_system).in_set(BigBrainSet::Actions),
         )
-        .add_system(thirsty_scorer_system.in_set(BigBrainSet::Scorers))
+        .add_systems(First, thirsty_scorer_system)
         .run();
 }

--- a/examples/thirst.rs
+++ b/examples/thirst.rs
@@ -164,13 +164,18 @@ fn main() {
             filter: "big_brain=debug,thirst=debug".to_string(),
             ..default()
         }))
-        .add_plugin(BigBrainPlugin)
-        .add_startup_system(init_entities)
-        .add_system(thirst_system)
-        // Big Brain has specific stages for Scorers and Actions. If
+        .add_plugins(BigBrainPlugin::new(PreUpdate))
+        .add_systems(Startup, init_entities)
+        .add_systems(Update, thirst_system)
+        // Big Brain has specific sets for Scorers and Actions. If
         // determinism matters a lot to you, you should add your action and
         // scorer systems to these stages.
-        .add_system(drink_action_system.in_set(BigBrainSet::Actions))
-        .add_system(thirsty_scorer_system.in_set(BigBrainSet::Scorers))
+        .add_systems(
+            PreUpdate,
+            (
+                drink_action_system.in_set(BigBrainSet::Actions),
+                thirsty_scorer_system.in_set(BigBrainSet::Scorers),
+            ),
+        )
         .run();
 }

--- a/src/choices.rs
+++ b/src/choices.rs
@@ -10,6 +10,7 @@ use crate::{
 
 /// Contains different types of Considerations and Actions
 #[derive(Debug, Clone, Reflect)]
+#[reflect(from_reflect = false)]
 pub struct Choice {
     pub(crate) scorer: Scorer,
     #[reflect(ignore)]
@@ -28,6 +29,7 @@ impl Choice {
 
 /// Builds a new [`Choice`].
 #[derive(Debug, Reflect)]
+#[reflect(from_reflect = false)]
 pub struct ChoiceBuilder {
     when_label: Option<String>,
     #[reflect(ignore)]

--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -726,6 +726,7 @@ impl ScorerBuilder for WinningScorerBuilder {
 /// # }
 /// ```
 #[derive(Component, Debug, Reflect)]
+#[reflect(from_reflect = false)]
 pub struct EvaluatingScorer {
     scorer: Scorer,
     evaluator_string: String,
@@ -777,6 +778,7 @@ pub fn evaluating_scorer_system(
 }
 
 #[derive(Debug, Reflect)]
+#[reflect(from_reflect = false)]
 pub struct EvaluatingScorerBuilder {
     #[reflect(ignore)]
     scorer: Arc<dyn ScorerBuilder>,
@@ -855,6 +857,7 @@ impl ScorerBuilder for EvaluatingScorerBuilder {
 /// ```
 
 #[derive(Component, Debug, Reflect)]
+#[reflect(from_reflect = false)]
 pub struct MeasuredScorer {
     threshold: f32,
     #[reflect(ignore)]
@@ -917,6 +920,7 @@ pub fn measured_scorers_system(
 }
 
 #[derive(Debug, Reflect)]
+#[reflect(from_reflect = false)]
 pub struct MeasuredScorerBuilder {
     threshold: f32,
     #[reflect(ignore)]

--- a/src/thinker.rs
+++ b/src/thinker.rs
@@ -28,7 +28,7 @@ use crate::{
 #[derive(Debug, Clone, Component, Copy, Reflect)]
 pub struct Actor(pub Entity);
 
-#[derive(Debug, Clone, Copy, Reflect, FromReflect)]
+#[derive(Debug, Clone, Copy, Reflect)]
 pub struct Action(pub Entity);
 
 impl Action {
@@ -61,7 +61,7 @@ impl ActionSpan {
     }
 }
 
-#[derive(Debug, Clone, Copy, Reflect, FromReflect)]
+#[derive(Debug, Clone, Copy, Reflect)]
 pub struct Scorer(pub Entity);
 
 #[derive(Debug, Clone, Component)]
@@ -128,6 +128,7 @@ impl ScorerSpan {
 /// }
 /// ```
 #[derive(Component, Debug, Reflect)]
+#[reflect(from_reflect = false)]
 pub struct Thinker {
     #[reflect(ignore)]
     picker: Arc<dyn Picker>,

--- a/tests/steps.rs
+++ b/tests/steps.rs
@@ -5,20 +5,15 @@ use big_brain::{pickers, prelude::*};
 fn steps() {
     println!("steps test");
     App::new()
-        .add_plugins(MinimalPlugins)
-        .add_plugin(BigBrainPlugin)
+        .add_plugins((MinimalPlugins, BigBrainPlugin::new(PreUpdate)))
         .init_resource::<GlobalState>()
-        .add_startup_system(setup)
-        .add_system(
-            no_failure_score
-                .in_base_set(CoreSet::First)
-                .before(BigBrainSet::Scorers),
+        .add_systems(Startup, setup)
+        .add_systems(Update, no_failure_score.before(BigBrainSet::Scorers))
+        .add_systems(
+            PreUpdate,
+            (action1, action2, exit_action, failure_action).in_set(BigBrainSet::Actions),
         )
-        .add_system(action1)
-        .add_system(action2)
-        .add_system(exit_action)
-        .add_system(failure_action)
-        .add_system(last.in_base_set(CoreSet::Last).before(BigBrainSet::Cleanup))
+        .add_systems(Last, last.before(BigBrainSet::Cleanup))
         .run();
     println!("end");
 }


### PR DESCRIPTION
Updates big-brain to bevy 0.11. Once again the changes aren't too crazy.

Some interesting things:
- Added the option to specify which Schedule things are run in.
- FromReflect happens by default for Reflect now, which we need to disable for many types that are almost impossible to construct.