### PR TITLE
Include actions in Init state when cancelling steps

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -325,7 +325,7 @@ pub fn steps_system(
                 #[cfg(feature = "trace")]
                 trace!("StepsAction has been cancelled. Cancelling current step {:?} before finalizing.", active_ent);
                 let mut step_state = states.get_mut(active_ent).expect("oops");
-                if *step_state == Requested || *step_state == Executing {
+                if *step_state == Requested || *step_state == Executing || *step_state == Init {
                     *step_state = Cancelled;
                 } else if *step_state == Failure || *step_state == Success {
                     *states.get_mut(seq_ent).unwrap() = step_state.clone();


### PR DESCRIPTION
This fixes an issue that causes the action to get "stuck" if an action is cancelled while in the `Init` state.

I think my understanding of the issue is incomplete because I wasn't able to write a test for the fix, but this does solve the problem I was having in my game where actors with large and complex `Thinker`s would occasionally and unpredictably get stuck and stop acting.