### PR TITLE
Add support for generic types in ScorerBuilder

### DIFF
--- a/tests/derive_scorer.rs
+++ b/tests/derive_scorer.rs
@@ -28,8 +28,8 @@ fn check_generic_macro() {
 #[derive(Debug, Clone, Component, ScorerBuilder)]
 #[scorer_label = "MyGenericWhereLabel"]
 pub struct MyGenericWhereScorer<T>
-    where
-        T: Clone + Send + Sync + std::fmt::Debug + 'static,
+where
+    T: Clone + Send + Sync + std::fmt::Debug + 'static,
 {
     pub value: T,
 }

--- a/tests/derive_scorer.rs
+++ b/tests/derive_scorer.rs
@@ -12,3 +12,30 @@ fn check_macro() {
     let scorer = MyScorer;
     assert_eq!(scorer.label(), Some("MyLabel"))
 }
+
+#[derive(Debug, Clone, Component, ScorerBuilder)]
+#[scorer_label = "MyGenericLabel"]
+pub struct MyGenericScorer<T: Clone + Send + Sync + std::fmt::Debug + 'static> {
+    pub value: T,
+}
+
+#[test]
+fn check_generic_macro() {
+    let scorer = MyGenericScorer { value: 0 };
+    assert_eq!(scorer.label(), Some("MyGenericLabel"))
+}
+
+#[derive(Debug, Clone, Component, ScorerBuilder)]
+#[scorer_label = "MyGenericWhereLabel"]
+pub struct MyGenericWhereScorer<T>
+    where
+        T: Clone + Send + Sync + std::fmt::Debug + 'static,
+{
+    pub value: T,
+}
+
+#[test]
+fn check_generic_where_macro() {
+    let scorer = MyGenericWhereScorer { value: 0 };
+    assert_eq!(scorer.label(), Some("MyGenericWhereLabel"))
+}


### PR DESCRIPTION
Essentially a one to one duplicate of the behavior added in #88, but for Scorers.