### PR TITLE
Upgrade to bevy 0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,12 @@ homepage = "https://github.com/zkat/big-brain"
 [workspace]
 
 [dependencies]
-bevy = { version = "0.14.0-rc.3", default-features = false }
+bevy = { version = "0.14.0", default-features = false }
 big-brain-derive = { version = "=0.19.0", path = "./derive" }
 
 [dev-dependencies]
-bevy = { version = "0.14.0-rc.3", default-features = true }
+bevy = { version = "0.14.0", default-features = true }
 rand = { version = "0.8.5", features = ["small_rng"] }
-bevy-scene-hook = { git = "https://github.com/stargazing-dino/bevy-scene-hook.git", branch = "update-14.0" }
 
 [features]
 trace = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ homepage = "https://github.com/zkat/big-brain"
 [workspace]
 
 [dependencies]
-bevy = { version = "0.13.2", default-features = false }
+bevy = { version = "0.14.0-rc.3", default-features = false }
 big-brain-derive = { version = "=0.19.0", path = "./derive" }
 
 [dev-dependencies]
-bevy = { version = "0.13.2", default-features = true }
+bevy = { version = "0.14.0-rc.3", default-features = true }
 rand = { version = "0.8.5", features = ["small_rng"] }
-bevy-scene-hook = "10.0.0"
+bevy-scene-hook = { git = "https://github.com/stargazing-dino/bevy-scene-hook.git", branch = "update-14.0" }
 
 [features]
 trace = []

--- a/examples/farming_sim.rs
+++ b/examples/farming_sim.rs
@@ -616,6 +616,7 @@ fn check_scene_loaded(
     for (entity, instance) in query.iter() {
         if scene_spawner.instance_is_ready(**instance) {
             commands.entity(entity).insert(SceneProcessed);
+
             let entities = scene_spawner
                 .iter_instance_entities(**instance)
                 .chain(std::iter::once(entity));
@@ -641,10 +642,10 @@ fn main() {
         // This observer will attach components to entities in the scene based on their names.
         .observe(
             |trigger: Trigger<SceneLoaded>,
-             other_query: Query<(Entity, &Name)>,
+             query: Query<(Entity, &Name)>,
              mut commands: Commands| {
                 for entity in trigger.event().entities.iter() {
-                    if let Ok((entity, name)) = other_query.get(*entity) {
+                    if let Ok((entity, name)) = query.get(*entity) {
                         let mut entity_commands = commands.entity(entity);
 
                         match name.as_str() {

--- a/examples/farming_sim.rs
+++ b/examples/farming_sim.rs
@@ -6,14 +6,14 @@
 //! - When not tired, find the farm field and harvest items over time
 //! - When inventory is full, find the market and sell items for money
 
-use bevy::{log::LogPlugin, prelude::*};
+use bevy::{color::palettes::css, log::LogPlugin, prelude::*};
 use bevy_scene_hook::{HookPlugin, HookedSceneBundle, SceneHook};
 use big_brain::prelude::*;
 use big_brain_derive::ActionBuilder;
 
-const DEFAULT_COLOR: Color = Color::BLACK;
-const SLEEP_COLOR: Color = Color::RED;
-const FARM_COLOR: Color = Color::BLUE;
+const DEFAULT_COLOR: Color = Color::Srgba(css::BLACK);
+const SLEEP_COLOR: Color = Color::Srgba(css::RED);
+const FARM_COLOR: Color = Color::Srgba(css::BLUE);
 const MAX_DISTANCE: f32 = 0.1;
 const MAX_INVENTORY_ITEMS: f32 = 20.0;
 const WORK_NEED_SCORE: f32 = 0.6;
@@ -608,7 +608,7 @@ fn main() {
             // Use `RUST_LOG=big_brain=trace,farming_sim=trace cargo run --example
             // farming_sim --features=trace` to see extra tracing output.
             filter: "big_brain=debug,farming_sim=debug".to_string(),
-            update_subscriber: None,
+            custom_layer: |_| None,
         }))
         .add_plugins(HookPlugin)
         .add_plugins(BigBrainPlugin::new(PreUpdate))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,10 @@ pub mod prelude {
     };
 }
 
-use bevy::{ecs::schedule::ScheduleLabel, prelude::*, utils::intern::Interned};
+use bevy::{
+    ecs::{intern::Interned, schedule::ScheduleLabel},
+    prelude::*,
+};
 
 /// Core [`Plugin`] for Big Brain behavior. Required for any of the
 /// [`Thinker`](thinker::Thinker)-related magic to work.

--- a/tests/steps.rs
+++ b/tests/steps.rs
@@ -70,7 +70,7 @@ fn exit_action(
             *state = ActionState::Executing;
         }
         if *state == ActionState::Executing {
-            app_exit_events.send(AppExit);
+            app_exit_events.send(AppExit::Success);
         }
     }
 }


### PR DESCRIPTION
Here are the changes that were required for the 0.14.0

https://bevyengine.org/learn/migration-guides/0-13-to-0-14/#make-appexit-more-specific-about-exit-reason

https://bevyengine.org/learn/migration-guides/0-13-to-0-14/#overhaul-color

https://bevyengine.org/learn/migration-guides/0-13-to-0-14/#moves-intern-and-label-modules-into-bevy-ecs

https://bevyengine.org/learn/migration-guides/0-13-to-0-14/#improve-tracing-layer-customization

The only change I'm skeptical of is the AppExit::Success. Now that I'm looking at it, I'm guessing the logic is saying, we should never hit that condition and thus we're gonna hard exit. So it'd be an error

---

More importantly, I've removed bevy-scene-hook as a dependency. I haven't seen the contributor active in a while and the code to replace it was small enough with the new native observer APIs.