### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ fn main() {
 
 #### bevy version and MSRV
 
-The current version of `big-brain` is compatible with `bevy` 0.14.0.
+The current version of `big-brain` (0.22) is compatible with `bevy` 0.15.0.
 
 The Minimum Supported Rust Version for `big-brain` should be considered to
 be the same as `bevy`'s, which as of the time of this writing was "the


### PR DESCRIPTION
Readme states, that current version (unspecified) is compatible with bevy 0.14. However newest version of bevy is 0.15. When checking `Cargo.toml` I found out that current version (0.22) has specified dependency of Bevy 0.15, thus we should be compatible with bevy 0.15. 
I've updated README.md to state `big_brain`'s version 0.22 is compatible with bevy 0.15