### PR TITLE
Update to bevy 0.16.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ homepage = "https://github.com/zkat/big-brain"
 [workspace]
 
 [dependencies]
-bevy = { version = "0.15.0", default-features = false }
+bevy = { version = "0.16.0-rc.1", default-features = false }
 big-brain-derive = { version = "=0.22.0", path = "./derive" }
 
 [dev-dependencies]
-bevy = { version = "0.15.0", default-features = true }
+bevy = { version = "0.16.0-rc.1", default-features = true }
 rand = { version = "0.8.5", features = ["small_rng"] }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "big-brain"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Kat Marchán <kzm@zkat.tech>"]
 edition = "2021"
 description = "Rusty Utility AI library"
@@ -16,7 +16,7 @@ homepage = "https://github.com/zkat/big-brain"
 
 [dependencies]
 bevy = { version = "0.16.0-rc.1", default-features = false }
-big-brain-derive = { version = "=0.22.0", path = "./derive" }
+big-brain-derive = { version = "=0.23.0", path = "./derive" }
 
 [dev-dependencies]
 bevy = { version = "0.16.0-rc.1", default-features = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ homepage = "https://github.com/zkat/big-brain"
 [workspace]
 
 [dependencies]
-bevy = { version = "0.16.0-rc.1", default-features = false }
+bevy = { version = "0.16.0-rc.1", default-features = false, features = ["bevy_log"] }
 big-brain-derive = { version = "=0.23.0", path = "./derive" }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ fn main() {
 
 #### bevy version and MSRV
 
-The current version of `big-brain` is compatible with `bevy` 0.14.0.
+The current version of `big-brain` is compatible with `bevy` 0.16.0.
 
 The Minimum Supported Rust Version for `big-brain` should be considered to
 be the same as `bevy`'s, which as of the time of this writing was "the

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "big-brain-derive"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Kat Marchán <kzm@zkat.tech>"]
 description = "Procedural macros to simplify implementation of Big Brain traits"
 documentation = "https://docs.rs/big-brain-derive"

--- a/examples/concurrent.rs
+++ b/examples/concurrent.rs
@@ -6,7 +6,6 @@
 
 use bevy::log::LogPlugin;
 use bevy::prelude::*;
-use bevy::utils::tracing::debug;
 use big_brain::prelude::*;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};

--- a/examples/custom_measure.rs
+++ b/examples/custom_measure.rs
@@ -1,9 +1,9 @@
 //! This example demonstrates how to build a custom measure and use that
 //! in a Thinker.
 
+use bevy::ecs::component::{ComponentMutability, Mutable};
 use bevy::log::LogPlugin;
 use bevy::prelude::*;
-use bevy::utils::tracing::debug;
 use big_brain::prelude::*;
 use big_brain::scorers::MeasuredScorer;
 
@@ -81,7 +81,7 @@ pub struct EatWaffles;
 
 fn eat_thing_action<
     TActionMarker: std::fmt::Debug + Component,
-    TActorMarker: Component + EatFood,
+    TActorMarker: Component<Mutability = Mutable> + EatFood,
 >(
     time: Res<Time>,
     mut items: Query<&mut TActorMarker>,

--- a/examples/custom_measure.rs
+++ b/examples/custom_measure.rs
@@ -1,7 +1,7 @@
 //! This example demonstrates how to build a custom measure and use that
 //! in a Thinker.
 
-use bevy::ecs::component::{ComponentMutability, Mutable};
+use bevy::ecs::component::Mutable;
 use bevy::log::LogPlugin;
 use bevy::prelude::*;
 use big_brain::prelude::*;

--- a/examples/farming_sim.rs
+++ b/examples/farming_sim.rs
@@ -483,6 +483,7 @@ fn init_entities(
     commands.insert_resource(AmbientLight {
         color: Color::WHITE,
         brightness: 700.0,
+        ..default()
     });
 
     commands.spawn((

--- a/examples/one_off.rs
+++ b/examples/one_off.rs
@@ -1,6 +1,5 @@
 use bevy::log::LogPlugin;
 use bevy::prelude::*;
-use bevy::utils::tracing::{debug, trace};
 use big_brain::prelude::*;
 
 #[derive(Clone, Component, Debug, ActionBuilder)]

--- a/examples/sequence.rs
+++ b/examples/sequence.rs
@@ -8,7 +8,6 @@
 
 use bevy::log::LogPlugin;
 use bevy::prelude::*;
-use bevy::utils::tracing::{debug, trace};
 use big_brain::prelude::*;
 
 /// First, we make a simple Position component.

--- a/examples/thirst.rs
+++ b/examples/thirst.rs
@@ -1,6 +1,5 @@
 use bevy::log::LogPlugin;
 use bevy::prelude::*;
-use bevy::utils::tracing::{debug, trace};
 use big_brain::prelude::*;
 
 // First, we define a "Thirst" component and associated system. This is NOT

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -287,8 +287,8 @@ pub fn steps_system(
                         let step_state = step_state.clone();
                         let mut seq_state = states.get_mut(seq_ent).expect("idk");
                         *seq_state = step_state;
-                        if let Some(ent) = cmd.get_entity(steps_action.active_ent.entity()) {
-                            ent.despawn_recursive();
+                        if let Ok(mut ent) = cmd.get_entity(steps_action.active_ent.entity()) {
+                            ent.despawn();
                         }
                     }
                     Success if steps_action.active_step == steps_action.steps.len() - 1 => {
@@ -298,16 +298,16 @@ pub fn steps_system(
                         let step_state = step_state.clone();
                         let mut seq_state = states.get_mut(seq_ent).expect("idk");
                         *seq_state = step_state;
-                        if let Some(ent) = cmd.get_entity(steps_action.active_ent.entity()) {
-                            ent.despawn_recursive();
+                        if let Ok(mut ent) = cmd.get_entity(steps_action.active_ent.entity()) {
+                            ent.despawn();
                         }
                     }
                     Success => {
                         #[cfg(feature = "trace")]
                         trace!("Step succeeded, but there's more steps. Spawning next action.");
                         // Deactivate current step and go to the next step
-                        if let Some(ent) = cmd.get_entity(steps_action.active_ent.entity()) {
-                            ent.despawn_recursive();
+                        if let Ok(mut ent) = cmd.get_entity(steps_action.active_ent.entity()) {
+                            ent.despawn();
                         }
 
                         steps_action.active_step += 1;

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -3,8 +3,6 @@
 use std::sync::Arc;
 
 use bevy::prelude::*;
-#[cfg(feature = "trace")]
-use bevy::utils::tracing::trace;
 
 use crate::thinker::{Action, ActionSpan, Actor};
 

--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -5,8 +5,6 @@
 use std::{cmp::Ordering, sync::Arc};
 
 use bevy::prelude::*;
-#[cfg(feature = "trace")]
-use bevy::utils::tracing::trace;
 
 use crate::{
     evaluators::Evaluator,

--- a/src/scorers.rs
+++ b/src/scorers.rs
@@ -6,6 +6,8 @@ use std::{cmp::Ordering, sync::Arc};
 
 use bevy::prelude::*;
 
+use bevy::log::debug;
+
 use crate::{
     evaluators::Evaluator,
     measures::{Measure, WeightedMeasure},

--- a/src/thinker.rs
+++ b/src/thinker.rs
@@ -15,9 +15,6 @@ use bevy::{
     prelude::*,
 };
 
-#[cfg(feature = "trace")]
-use bevy::utils::tracing::trace;
-
 use crate::{
     actions::{self, ActionBuilder, ActionBuilderWrapper, ActionState},
     choices::{Choice, ChoiceBuilder},

--- a/src/thinker.rs
+++ b/src/thinker.rs
@@ -9,6 +9,7 @@ use std::{
 
 use bevy::{
     log::{
+        debug,
         tracing::{field, span, Span},
         Level,
     },

--- a/tests/steps.rs
+++ b/tests/steps.rs
@@ -70,7 +70,7 @@ fn exit_action(
             *state = ActionState::Executing;
         }
         if *state == ActionState::Executing {
-            app_exit_events.send(AppExit::Success);
+            app_exit_events.write(AppExit::Success);
         }
     }
 }


### PR DESCRIPTION
Updated to bevy 0.16.0-rc.1. Everything compiles and all tests succeed.

Note: `despawn_recursive` is now deprecated and `despawn` automatically despawns children.