### PR TITLE
replace std::time:instant with bevy::platform::time::instant

### DIFF
--- a/src/thinker.rs
+++ b/src/thinker.rs
@@ -4,7 +4,7 @@
 use std::{
     collections::VecDeque,
     sync::Arc,
-    time::{Duration, Instant},
+    time::Duration
 };
 
 use bevy::{
@@ -13,6 +13,7 @@ use bevy::{
         Level,
     },
     prelude::*,
+    platform::time::Instant
 };
 
 use crate::{


### PR DESCRIPTION
see [issues/117](https://github.com/zkat/big-brain/issues/117)

All tests pass and compile and it no longer seems to panic in wasm builds.